### PR TITLE
Mark this repo as language: Dockerfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
Dockerfiles with extension are now marked as Dockerfile.

Related issue: github/linguist#4566