### PR TITLE
Create Dockerfile.alpine.minimal a 97MB alpine based docker image

### DIFF
--- a/docker/vlang/Dockerfile.alpine.minimal
+++ b/docker/vlang/Dockerfile.alpine.minimal
@@ -1,0 +1,52 @@
+FROM alpine:latest AS vlang-sdk
+MAINTAINER msheriffusa <msheriffusa@gmail.com>
+
+WORKDIR /opt/v/
+
+# 215MB
+RUN apk add --update alpine-sdk
+
+# 30MB
+RUN wget https://github.com/vlang/v/releases/download/0.4.4/v_linux.zip -O /opt/v.zip
+# 90MB
+RUN unzip /opt/v.zip -d /opt/
+
+RUN make && ./v symlink
+
+# delete files not required in a docker run image
+RUN rm -rf doc
+RUN rm -rf examples/
+RUN rm -rf tutorials/
+RUN rm -rf vc
+RUN rm -rf ./vlib/v/tests/
+RUN rm -rf ./vlib/v/slow_tests/
+RUN rm -rf ./vlib/v/embed_file/tests/
+RUN rm -rf ./cmd/tools/vdoc/tests
+RUN rm -rf ./cmd/tools/vcreate/tests
+RUN rm -rf ./cmd/tools/vvet/tests
+RUN rm -rf ./vlib/v/scanner/tests/
+RUN rm -rf ./vlib/v/fmt/tests
+RUN rm -rf ./vlib/v/checker/tests
+RUN rm -rf ./vlib/v/gen/native/tests
+RUN rm -rf ./vlib/v/gen/wasm/tests
+RUN rm -rf ./vlib/v/gen/js/tests
+RUN rm -rf ./vlib/v/eval/tests
+RUN rm -rf ./vlib/v/gen/golang/tests
+RUN rm -rf ./vlib/v/parser/tests/
+RUN rm -rf ./vlib/toml/tests/
+RUN rm -rf ./vlib/net/websocket/tests
+RUN rm -rf ./vlib/x/vweb/tests
+RUN rm -rf ./vlib/vweb/tests
+RUN rm -rf ./vlib/v2/tests
+RUN rm -rf ./vlib/wasm/tests
+
+FROM alpine:latest AS vlang
+MAINTAINER msheriffusa <msheriffusa@gmail.com>
+WORKDIR /opt/
+# 90MB
+COPY --from=vlang-sdk /opt/v/ .
+# 215MB
+RUN apk add --update alpine-sdk
+RUN ./v symlink
+
+CMD ["v"]

--- a/docker/vlang/Dockerfile.alpine.minimal
+++ b/docker/vlang/Dockerfile.alpine.minimal
@@ -11,7 +11,7 @@ RUN wget https://github.com/vlang/v/releases/download/0.4.4/v_linux.zip -O /opt/
 # 90MB
 RUN unzip /opt/v.zip -d /opt/
 
-RUN make && ./v symlink
+RUN make
 
 # delete files not required in a docker run image
 RUN rm -rf doc

--- a/docker/vlang/Dockerfile.alpine.minimal
+++ b/docker/vlang/Dockerfile.alpine.minimal
@@ -15,7 +15,16 @@ RUN unzip /opt/v.zip -d /opt/
 RUN make
 
 # delete files not required in a docker run image (removes 25 dirs)
-RUN rm -rf doc examples/ tutorials/ vc/ ./vlib/v/tests/ ./vlib/v/slow_tests/ ./vlib/v/embed_file/tests/ ./cmd/tools/vdoc/tests ./cmd/tools/vcreate/tests ./cmd/tools/vvet/tests ./vlib/v/scanner/tests/ ./vlib/v/fmt/tests ./vlib/v/checker/tests ./vlib/v/gen/native/tests ./vlib/v/gen/wasm/tests ./vlib/v/gen/js/tests ./vlib/v/eval/tests ./vlib/v/gen/golang/tests ./vlib/v/parser/tests/ ./vlib/toml/tests/ ./vlib/net/websocket/tests ./vlib/x/vweb/tests ./vlib/vweb/tests ./vlib/v2/tests ./vlib/wasm/tests
+RUN rm -rf doc examples/ tutorials/ vc/ ./vlib/v/tests/ \
+    ./vlib/v/slow_tests/ ./vlib/v/embed_file/tests/ \
+    ./cmd/tools/vdoc/tests ./cmd/tools/vcreate/tests \
+    ./cmd/tools/vvet/tests ./vlib/v/scanner/tests/ \
+    ./vlib/v/fmt/tests ./vlib/v/checker/tests \
+    ./vlib/v/gen/native/tests ./vlib/v/gen/wasm/tests \
+    ./vlib/v/gen/js/tests ./vlib/v/eval/tests \
+    ./vlib/v/gen/golang/tests ./vlib/v/parser/tests/ \
+    ./vlib/toml/tests/ ./vlib/net/websocket/tests \
+    ./vlib/x/vweb/tests ./vlib/vweb/tests ./vlib/v2/tests ./vlib/wasm/tests
 
 FROM alpine:latest AS vlang
 MAINTAINER msheriffusa <msheriffusa@gmail.com>

--- a/docker/vlang/Dockerfile.alpine.minimal
+++ b/docker/vlang/Dockerfile.alpine.minimal
@@ -8,45 +8,25 @@ RUN apk add --update alpine-sdk
 
 # 30MB
 RUN wget https://github.com/vlang/v/releases/download/0.4.4/v_linux.zip -O /opt/v.zip
+
 # 90MB
 RUN unzip /opt/v.zip -d /opt/
 
 RUN make
 
-# delete files not required in a docker run image
-RUN rm -rf doc
-RUN rm -rf examples/
-RUN rm -rf tutorials/
-RUN rm -rf vc
-RUN rm -rf ./vlib/v/tests/
-RUN rm -rf ./vlib/v/slow_tests/
-RUN rm -rf ./vlib/v/embed_file/tests/
-RUN rm -rf ./cmd/tools/vdoc/tests
-RUN rm -rf ./cmd/tools/vcreate/tests
-RUN rm -rf ./cmd/tools/vvet/tests
-RUN rm -rf ./vlib/v/scanner/tests/
-RUN rm -rf ./vlib/v/fmt/tests
-RUN rm -rf ./vlib/v/checker/tests
-RUN rm -rf ./vlib/v/gen/native/tests
-RUN rm -rf ./vlib/v/gen/wasm/tests
-RUN rm -rf ./vlib/v/gen/js/tests
-RUN rm -rf ./vlib/v/eval/tests
-RUN rm -rf ./vlib/v/gen/golang/tests
-RUN rm -rf ./vlib/v/parser/tests/
-RUN rm -rf ./vlib/toml/tests/
-RUN rm -rf ./vlib/net/websocket/tests
-RUN rm -rf ./vlib/x/vweb/tests
-RUN rm -rf ./vlib/vweb/tests
-RUN rm -rf ./vlib/v2/tests
-RUN rm -rf ./vlib/wasm/tests
+# delete files not required in a docker run image (removes 25 dirs)
+RUN rm -rf doc examples/ tutorials/ vc/ ./vlib/v/tests/ ./vlib/v/slow_tests/ ./vlib/v/embed_file/tests/ ./cmd/tools/vdoc/tests ./cmd/tools/vcreate/tests ./cmd/tools/vvet/tests ./vlib/v/scanner/tests/ ./vlib/v/fmt/tests ./vlib/v/checker/tests ./vlib/v/gen/native/tests ./vlib/v/gen/wasm/tests ./vlib/v/gen/js/tests ./vlib/v/eval/tests ./vlib/v/gen/golang/tests ./vlib/v/parser/tests/ ./vlib/toml/tests/ ./vlib/net/websocket/tests ./vlib/x/vweb/tests ./vlib/vweb/tests ./vlib/v2/tests ./vlib/wasm/tests
 
 FROM alpine:latest AS vlang
 MAINTAINER msheriffusa <msheriffusa@gmail.com>
 WORKDIR /opt/
+
 # 90MB
 COPY --from=vlang-sdk /opt/v/ .
+
 # 215MB
 RUN apk add --update alpine-sdk
+
 RUN ./v symlink
 
 CMD ["v"]


### PR DESCRIPTION
A 97MB alpine based docker image stripped of tests, examples, docs, tutorials

| Size | By |
| --- | --- |
| 48MB | v |
| 49MB | alpine + gcc + git |
